### PR TITLE
Added injection for SpringerLink

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Please contribute new websites!
 - Elsevier / ScienceDirect
 - Eureka Select
 - Science
+- SpringerLink
 
 ## Screenshots
 

--- a/inject.js
+++ b/inject.js
@@ -131,6 +131,8 @@ function springerLink() {
     springerLinkArticle(doi);
   } else if (url.includes('book')) {
     springerLinkBook(doi);
+  } else if (url.includes('chapter')) {
+    springerLinkChapter(doi);
   }
 }
 
@@ -170,6 +172,18 @@ function springerLinkBook(doi) {
         View On SciHub
       </a>
     </span>
+  `;
+}
+
+function springerLinkChapter(doi) {
+  const contextContainer = document.querySelector('.main-context__container');
+  contextContainer.innerHTML += `
+    <div style="align-self:center">
+      <a href="${sciHubLink(doi)}" title="SciHub">
+        <img width=24 height=24 src="https://sci-hub.se/misc/img/ravenround.gif" style="width:24px; vertical-align:bottom"/>
+        View On SciHub
+      </a>
+    </div>
   `;
 }
 

--- a/inject.js
+++ b/inject.js
@@ -125,14 +125,12 @@ function wiley() {
 function springerLink() {
   const url = document.location.href;
   const doi = getSpringerDoi(url);
-  if (url.includes('journal')) {
+  if (url.includes("journal")) {
     springerLinkJournal();
-  } else if (url.includes('article')) {
+  } else if (url.includes("article")) {
     springerLinkArticle(doi);
-  } else if (url.includes('book')) {
-    springerLinkBook(doi);
-  } else if (url.includes('chapter')) {
-    springerLinkChapter(doi);
+  } else {
+    springerLinkGeneral(doi);
   }
 }
 
@@ -141,11 +139,11 @@ function getSpringerDoi(url) {
 }
 
 function springerLinkJournal() {
-  const articleListElements = Array.from(document.querySelectorAll('.app-volumes-and-issues__article-list > li'));
+  const articleListElements = Array.from(document.querySelectorAll(".app-volumes-and-issues__article-list > li"));
   for (const articleElement of articleListElements) {
-    const articleUrl = articleElement.querySelector('h3 a').getAttribute('href');
+    const articleUrl = articleElement.querySelector("h3 a").getAttribute("href");
     const doi = getSpringerDoi(articleUrl);
-    articleElement.querySelector('.c-meta').innerHTML += `
+    articleElement.querySelector(".c-meta").innerHTML += `
       <li class="c-meta__item c-meta__item--block-sm-max">
         <a href="${sciHubLink(doi)}" title="SciHub">View on SciHub</a>
       </li>
@@ -154,7 +152,7 @@ function springerLinkJournal() {
 }
 
 function springerLinkArticle(doi) {
-  const details = document.querySelector('.c-article-info-details');
+  const details = document.querySelector(".c-article-info-details");
   details.innerHTML += `
     <a class="c-article-info-details__cite-as" href="${sciHubLink(doi)}" title="SciHub">
       <img width=24 height=24 src="https://sci-hub.se/misc/img/ravenround.gif" style="vertical-align:bottom"/>
@@ -163,20 +161,8 @@ function springerLinkArticle(doi) {
   `;
 }
 
-function springerLinkBook(doi) {
-  const describeSection = document.querySelector('.evaluation-section__text-col');
-  describeSection.innerHTML += `
-    <span class="c-box" style="margin-bottom:1rem; display:inline-block">
-      <a href="${sciHubLink(doi)}" title="SciHub">
-        <img width=24 height=24 src="https://sci-hub.se/misc/img/ravenround.gif" style="vertical-align:bottom"/>
-        View On SciHub
-      </a>
-    </span>
-  `;
-}
-
-function springerLinkChapter(doi) {
-  const contextContainer = document.querySelector('.main-context__container');
+function springerLinkGeneral(doi) {
+  const contextContainer = document.querySelector(".main-context__container") || document.getElementById("book-metrics");
   contextContainer.innerHTML += `
     <div style="align-self:center">
       <a href="${sciHubLink(doi)}" title="SciHub">

--- a/inject.js
+++ b/inject.js
@@ -127,6 +127,8 @@ function springerLink() {
   const doi = getSpringerDoi(url);
   if (url.includes('journal')) {
     springerLinkJournal();
+  } else if (url.includes('article')) {
+    springerLinkArticle(doi);
   }
 }
 
@@ -145,7 +147,16 @@ function springerLinkJournal() {
       </li>
     `;
   }
+}
 
+function springerLinkArticle(doi) {
+  const details = document.querySelector('.c-article-info-details');
+  details.innerHTML += `
+    <a class="c-article-info-details__cite-as" href="${sciHubLink(doi)}" title="SciHub">
+      <img width=24 height=24 src="https://sci-hub.se/misc/img/ravenround.gif" style="vertical-align:bottom"/>
+      View On SciHub
+    </a>
+  `;
 }
 
 function addSciHubLink() {

--- a/inject.js
+++ b/inject.js
@@ -129,11 +129,13 @@ function springerLink() {
     springerLinkJournal();
   } else if (url.includes('article')) {
     springerLinkArticle(doi);
+  } else if (url.includes('book')) {
+    springerLinkBook(doi);
   }
 }
 
 function getSpringerDoi(url) {
-  return url.match(/10.+?[^#]+/)?.[0];
+  return decodeURIComponent(url).match(/10.+?[^#]+/)?.[0];
 }
 
 function springerLinkJournal() {
@@ -156,6 +158,18 @@ function springerLinkArticle(doi) {
       <img width=24 height=24 src="https://sci-hub.se/misc/img/ravenround.gif" style="vertical-align:bottom"/>
       View On SciHub
     </a>
+  `;
+}
+
+function springerLinkBook(doi) {
+  const describeSection = document.querySelector('.evaluation-section__text-col');
+  describeSection.innerHTML += `
+    <span class="c-box" style="margin-bottom:1rem; display:inline-block">
+      <a href="${sciHubLink(doi)}" title="SciHub">
+        <img width=24 height=24 src="https://sci-hub.se/misc/img/ravenround.gif" style="vertical-align:bottom"/>
+        View On SciHub
+      </a>
+    </span>
   `;
 }
 

--- a/inject.js
+++ b/inject.js
@@ -122,6 +122,32 @@ function wiley() {
   `;
 }
 
+function springerLink() {
+  const url = document.location.href;
+  const doi = getSpringerDoi(url);
+  if (url.includes('journal')) {
+    springerLinkJournal();
+  }
+}
+
+function getSpringerDoi(url) {
+  return url.match(/10.+?[^#]+/)?.[0];
+}
+
+function springerLinkJournal() {
+  const articleListElements = Array.from(document.querySelectorAll('.app-volumes-and-issues__article-list > li'));
+  for (const articleElement of articleListElements) {
+    const articleUrl = articleElement.querySelector('h3 a').getAttribute('href');
+    const doi = getSpringerDoi(articleUrl);
+    articleElement.querySelector('.c-meta').innerHTML += `
+      <li class="c-meta__item c-meta__item--block-sm-max">
+        <a href="${sciHubLink(doi)}" title="SciHub">View on SciHub</a>
+      </li>
+    `;
+  }
+
+}
+
 function addSciHubLink() {
   const url = document.location.href;
   if (url.includes("pubmed.ncbi.nlm.nih.gov")) {
@@ -138,6 +164,8 @@ function addSciHubLink() {
     science();
   } else if (url.includes("wiley.com")) {
     wiley();
+  } else if (url.includes("link.springer.com")) {
+    springerLink();
   }
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,8 @@
         "https://www.sciencedirect.com/*",
         "http://www.eurekaselect.com/*",
         "https://www.science.org/*",
-        "https://dom-pubs.onlinelibrary.wiley.com/doi/*"
+        "https://dom-pubs.onlinelibrary.wiley.com/doi/*",
+        "https://link.springer.com/*"
       ],
       "js": ["inject.js"]
     }


### PR DESCRIPTION
I added SciHub injection for SpringerLink. This includes journals, articles, books, chapters, conference papers, reference work, reference work entries and protocols.

Here is every different type of content as an example:

## [Journal](https://link.springer.com/journal/12668/volumes-and-issues/11-4)
![Screenshot 2022-01-16 at 14 56 46](https://user-images.githubusercontent.com/39100405/149663046-2c84fe5f-a106-4874-a1f8-726b44a4c4a4.png)

The journal page is different from the default SpringerLink page as it's a collection of articles. The SciHub link gets injected for every article and is shown next to the pages.

---

## [Article](https://link.springer.com/article/10.1007/s12668-021-00888-5)
![Screenshot 2022-01-16 at 14 59 14](https://user-images.githubusercontent.com/39100405/149663125-ebb9f731-8581-4473-ab77-170404253c2f.png)

For the article page the SciHub link is injected next to the "Cite this article" link.

---

## General 
![Screenshot 2022-01-16 at 15 01 26](https://user-images.githubusercontent.com/39100405/149663233-15b48987-b37a-4287-9c58-b2a37f68e866.png)

For every other type of content, the SciHub link is shown next to the metrics.

[Book](https://link.springer.com/book/10.1057%2F978-1-137-56736-9)
[Chapter](https://link.springer.com/chapter/10.1007/698_2020_692)
[Conference Paper](https://link.springer.com/chapter/10.1007/978-3-030-57884-8_59)
[Reference Work](https://link.springer.com/referencework/10.1007/978-3-319-44680-6)
[Reference Work Entry](https://link.springer.com/referenceworkentry/10.1007/978-3-319-75381-2_17-1)
[Protocol](https://link.springer.com/protocol/10.1007/7651_2020_334)